### PR TITLE
Limit the table of contents to H2s

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,8 @@ relative_permalinks: false
 gems:
   - jekyll-redirect-from
 
+kramdown:
+  toc_levels: "1,2"
 
 # original settings
 

--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ title: FITARA
 ### Sections and Attachments
 
 * Table of Contents
-{:toc max_level=2 }
+{:toc}
 
 ## Introduction
 The Federal Information Technology Acquisition Reform Act ([FITARA)](https://www.congress.gov/113/plaws/publ291/PLAW-113publ291.pdf#page=148]), passed by Congress in December 2014, is a historic law that represents the first major overhaul of Federal information technology (IT) in almost 20 years. Since FITARA’s passage, OMB has been developing guidance to agencies to ensure that this law is applied consistently government-wide in a way that is both workable and effective. In a time of unprecedented opportunity for technology to accelerate the quality and timeliness of services delivered to the American people, the importance of ensuring successful management and oversight of IT, including the successful implementation of FITARA, cannot be overstated.


### PR DESCRIPTION
Via https://github.com/WhiteHouse/fitara/pull/7#issuecomment-98155283, this pull request instructs the table of contents to be limited to H2's via Kramdown's configuration. See [the Kramdown documentation](http://kramdown.gettalong.org/converter/html.html#toc) for more information.
## Before

![screen shot 2015-05-01 at 11 58 38 am](https://cloud.githubusercontent.com/assets/282759/7432815/6fa802de-eff9-11e4-93e1-c7e14bdf13fe.png)
## After

![screen shot 2015-05-01 at 11 57 34 am](https://cloud.githubusercontent.com/assets/282759/7432806/6013ff6c-eff9-11e4-98b7-be5be6a7d1cb.png)

/cc @jlberryhill #8, #9, #10
