### PR TITLE
redressing bullet points from #17

### DIFF
--- a/index.md
+++ b/index.md
@@ -494,35 +494,35 @@ When conducting TechStat reviews, PortfolioStat reviews, or evaluating investmen
 Agencies shall evaluate their performance in each of the following areas by comparing their performance to a set of criteria provided by OMB describing performance at three levels: (1) "Reacting", (2) "Implementing", and (3) "Optimizing". More information will be provided as a part of the PortfolioStat process.
   
 **Management**  
-* Program/Project Management  
-* Portfolio Management  
-* Enterprise    
-* Strategy  
-* Financial Management  
+ - Program/Project Management  
+ - Portfolio Management  
+ - Enterprise    
+ - Strategy  
+ - Financial Management  
   
 **People**  
-* Leadership  
-* Accountability  
-* Talent/HRM  
-* Customer-Centric  
+ - Leadership  
+ - Accountability  
+ - Talent/HRM  
+ - Customer-Centric  
   
 **Process**  
-* Governance  
-* Agile  
-* Transparency  
-* Complexity  
+ - Governance  
+ - Agile  
+ - Transparency  
+ - Complexity  
   
 **Technology**  
-* Security  
-* Scalability  
-* Open  
-* Reuse  
+ - Security  
+ - Scalability  
+ - Open  
+ - Reuse  
   
 **Acquisition**  
-* Strategic Sourcing  
-* Flexibility  
-* Scope  
-* Lock-in  
+ - Strategic Sourcing  
+ - Flexibility  
+ - Scope  
+ - Lock-in  
   
 _[Return to the Top]()_
 


### PR DESCRIPTION
I'd thought that the regular markdown way of making bullet points would work best in #17, but they look like this:  

![screen shot 2015-05-04 at 1 54 02 pm](https://cloud.githubusercontent.com/assets/633088/7458771/169d00e0-f265-11e4-8f96-216fa8e13ced.png)

This edit brings them into line with the style used elsewhere in the page.  
