### PR TITLE
Switch canonical hostname to management.cio.gov

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,11 +3,11 @@
 #document settings
 title: Management and Oversight of Information Technology Resources
 desc: Proposed Guidance From the Office of Management and Budget (OMB)
-url: https://whitehouse.github.io/fitara/
+url: https://management.cio.gov
 
 #global settings, no need to change these
-root_url: https://whitehouse.github.io/fitara/
-production_hostname: whitehouse.github.io
+root_url: https://management.cio.gov
+production_hostname: management.cio.gov
 org_name: whitehouse
 repo_name: fitara
 branch: gh-pages

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,15 +6,15 @@
           <a class="btn btn-primary" href="{{ edit_url }}">Edit this Page</a>
         </div>
 <!--        <div class="pull-right">
-          <iframe src=https://whitehouse.github.io/fitara/assets/ghbtns/github-btn.html?user={{ site.org_name }}&repo={{ site.repo_name }}&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>
+          <iframe src=https://management.cio.gov/assets/ghbtns/github-btn.html?user={{ site.org_name }}&repo={{ site.repo_name }}&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>
         </div>-->
       </div>
     </div>
   </div><!-- /container -->
 
 
-  <script src="https://whitehouse.github.io/fitara/assets/js/vendor/jquery-1.11.1.min.js"></script>
-  <script src="https://whitehouse.github.io/fitara/assets/js/bootstrap.min.js"></script>
+  <script src="https://management.cio.gov/assets/js/vendor/jquery-1.11.1.min.js"></script>
+  <script src="https://management.cio.gov/assets/js/bootstrap.min.js"></script>
 <!-- DAP code -->
 <script id="_fed_an_ua_tag" type="text/javascript" src="https://cio.gov/wp-content/themes/twentyten/assets/js/federated-analytics.js?agency=GSA&sub-agency=OGP&pua=UA-46219405-1"></script>
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,15 +6,15 @@
           <a class="btn btn-primary" href="{{ edit_url }}">Edit this Page</a>
         </div>
 <!--        <div class="pull-right">
-          <iframe src=https://management.cio.gov/assets/ghbtns/github-btn.html?user={{ site.org_name }}&repo={{ site.repo_name }}&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>
+          <iframe src={{ site.url }}/assets/ghbtns/github-btn.html?user={{ site.org_name }}&repo={{ site.repo_name }}&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>
         </div>-->
       </div>
     </div>
   </div><!-- /container -->
 
 
-  <script src="https://management.cio.gov/assets/js/vendor/jquery-1.11.1.min.js"></script>
-  <script src="https://management.cio.gov/assets/js/bootstrap.min.js"></script>
+  <script src="{{ site.url }}/assets/js/vendor/jquery-1.11.1.min.js"></script>
+  <script src="{{ site.url }}/assets/js/bootstrap.min.js"></script>
 <!-- DAP code -->
 <script id="_fed_an_ua_tag" type="text/javascript" src="https://cio.gov/wp-content/themes/twentyten/assets/js/federated-analytics.js?agency=GSA&sub-agency=OGP&pua=UA-46219405-1"></script>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,9 +11,9 @@
 
   <title>OMB - Management and Oversight of Federal IT Public Feedback</title>
 
-  <link rel="shortcut icon" href="https://management.cio.gov/favicon.ico"/>
-  <link rel="stylesheet" href="https://management.cio.gov/assets/css/bootstrap.css">
-  <link rel="stylesheet" href="https://management.cio.gov/assets/css/site.css">
+  <link rel="shortcut icon" href="{{ site.url }}/favicon.ico"/>
+  <link rel="stylesheet" href="{{ site.url }}/assets/css/bootstrap.css">
+  <link rel="stylesheet" href="{{ site.url }}/assets/css/site.css">
 
   <link rel="canonical" href="{{ site.url }}{{ page.url }}" />
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,9 +11,9 @@
 
   <title>OMB - Management and Oversight of Federal IT Public Feedback</title>
 
-  <link rel="shortcut icon" href="https://whitehouse.github.io/fitara/favicon.ico"/>
-  <link rel="stylesheet" href="https://whitehouse.github.io/fitara/assets/css/bootstrap.css">
-  <link rel="stylesheet" href="https://whitehouse.github.io/fitara/assets/css/site.css">
+  <link rel="shortcut icon" href="https://management.cio.gov/favicon.ico"/>
+  <link rel="stylesheet" href="https://management.cio.gov/assets/css/bootstrap.css">
+  <link rel="stylesheet" href="https://management.cio.gov/assets/css/site.css">
 
   <link rel="canonical" href="{{ site.url }}{{ page.url }}" />
 


### PR DESCRIPTION
Since the site has moved to management.cio.gov, this updates the site to tell Google that that's the canonical URL, and pulls resources down from management.cio.gov rather than whitehouse.github.io. This reduces third-party service pings, and should improve performance at least somewhat.

This also further future-proofs the site to not require being hosted at a GitHub repo (much less a GitHub repo at a particular org and with a particular repo name).
