### PR TITLE
Refine organization and workforce section

### DIFF
--- a/index.md
+++ b/index.md
@@ -317,9 +317,9 @@ BUDGET FORMULATION.—The Director of the Office of Management and Budget shall 
 
 ### Organization and Workforce
 
-##### CIO approves new bureau CIOs
+##### CIO approves bureau CIOs
 
- - M1. *CIO Role/Responsibility*: CIO approves new bureau CIOs. The CIO shall be involved in the recruitment and shall approve the selection of any new bureau CIO (includes bureau leadership with CIO duties but not title—see definitions).
+ - M1. *CIO Role/Responsibility*: CIO approves bureau CIOs. The CIO shall approve the selection of any bureau CIO (includes bureau leadership with CIO duties but not title—see definitions). The CIO shall also be involved in the recruitment and shall approve the selection of any new bureau CIO.
  - *Statutory Language*: PERSONNEL-RELATED AUTHORITY.—Notwithstanding any other provision of law, for each covered agency … the Chief Information Officer of the covered agency shall approve the appointment of any other employee with the title of Chief Information Officer, or who functions in the capacity of a Chief Information Officer, for any component organization within the covered agency. 40 U.S.C. 11319 (b)(2)
 
 ##### CIO role in ongoing bureau CIOs’ evaluations


### PR DESCRIPTION
Modify the organization and workforce section to better align the guidance with the statutory language contained in Section 11319 (b)(2) of Title 40, United States Code, and with the congressional intent underlying 40 USC 11319 (b)(2), that the Chief Information Officer (CIO) at each covered agency, notwithstanding any other provision of law, shall approve the appointment of any employee that holds the title CIO or who functions in the capacity of a CIO, for any component organization within the covered agency.

40 USC 11319 (b)(2) provides a covered agency CIO with the necessary authority to create clear lines of responsibility, authority, and accountability over the management of Federal IT investments within the covered agency. This provision of FITARA directly addresses an issue that was raised in the House Committee report for H.R. 1232, which noted that many federated agencies, "have numerous CIOs at their component organizations with little or no accountability to the central agency CIO."

Covered agencies should be aware that this new approval authority established by FITARA is not solely prospective. FITARA contains no clear statutory prohibition preventing a covered agency CIO from implementing the requirement to "approve the appointment of any other employee with the title of Chief Information Officer" in the present. Of course, such an action would need to be appropriately carried out by the covered agency CIO in a systematic and merit-based manner that provides a full and detailed justification for the approval decision.

In addition, it is important to note that I strongly concur with item number four in the scope and applicability section of the proposed guidance that states, "With respect to Offices of Inspectors General (OIG), this guidance should be implemented in a manner that does not impact the independence of those offices and the authorities Inspectors General have over the personnel, performance, procurement, and budget of the OIG, as provided in the IG Act of 1978, 5 U.S.C. app 3." Accordingly, with respect to complying with 40 USC 11319 (b)(2), no covered agency OIG should be considered to be a "component organization within the covered agency."
