### PR TITLE
fitaramilestones.json destination

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -32,6 +32,8 @@ The following resources contain helpful tools for working with JSON data format:
 
 ## Agency FITARA Milestones
 
+Post a "fitaramilestones.json" file to "agency.gov"/digitalstrategy with the following contents.
+
 First, each milestones JSON document must include a "milestoneDocument" section providing the overall date of last update to the milestones items.
 
 {: .table .table-striped}


### PR DESCRIPTION
consider if you prefer agencies use this filename ("fitaramilestones.json") or something else (like "milestones.json"). An instruction with a mix of upper and lowercase letters may be confusing as some agencies may ignore the case instructions when posting their file, which, depending on the circumstances, may make it more difficult to find their files. Consequently, "FITARAMilestones.json" may be less attractive as an option, for example.
